### PR TITLE
add es build (expose es module in package) + add custom formatter

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,16 +1,35 @@
 {
-  "presets": [
-    ["env", {
-        "targets": [
-          "node",
-          "chrome",
-          "edge",
-          "firefox"
-        ]
-      }]
-  ],
+  "env": {
+    "commonjs": {
+      "presets": [
+        ["env", {
+            "targets": [
+              "node",
+              "chrome",
+              "edge",
+              "firefox"
+            ]
+          }]
+      ],
+      "plugins": [
+        "add-module-exports"
+      ]
+    },
+    "esm": {
+      "presets": [
+        ["env", {
+            "targets": [
+              "node",
+              "chrome",
+              "edge",
+              "firefox"
+            ],
+            "modules": false
+          }]
+      ]
+    }
+  },
   "plugins": [
-    "transform-object-rest-spread",
-    "add-module-exports"
+    "transform-object-rest-spread"
   ]
 }

--- a/lib/index.esm.js
+++ b/lib/index.esm.js
@@ -1,16 +1,10 @@
-'use strict';
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
-
-var _lodash = require('lodash');
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
+
+import { each, mapValues } from 'lodash';
 
 var defaultOptions = {
   localName: 'local'
@@ -19,10 +13,10 @@ var defaultFormatter = function defaultFormatter(value) {
   return value;
 };
 
-exports.default = function (props) {
+export default (function (props) {
   var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : defaultOptions;
 
-  var propsDefinitions = (0, _lodash.mapValues)(props, function (_ref) {
+  var propsDefinitions = mapValues(props, function (_ref) {
     var prop = _objectWithoutProperties(_ref, []),
         formatter = _ref.formatter;
 
@@ -33,7 +27,7 @@ exports.default = function (props) {
     data: function data() {
       var _this = this;
 
-      return _defineProperty({}, options.localName, _extends({}, (0, _lodash.mapValues)(props, function (_ref2, propName) {
+      return _defineProperty({}, options.localName, _extends({}, mapValues(props, function (_ref2, propName) {
         var _ref2$formatter = _ref2.formatter,
             formatter = _ref2$formatter === undefined ? defaultFormatter : _ref2$formatter;
         return formatter(_this[propName]);
@@ -42,7 +36,7 @@ exports.default = function (props) {
     created: function created() {
       var _this2 = this;
 
-      (0, _lodash.each)(props, function (_ref4, propName) {
+      each(props, function (_ref4, propName) {
         var _ref4$formatter = _ref4.formatter,
             formatter = _ref4$formatter === undefined ? defaultFormatter : _ref4$formatter;
 
@@ -52,6 +46,4 @@ exports.default = function (props) {
       });
     }
   };
-};
-
-module.exports = exports['default'];
+});

--- a/lib/index.esm.js
+++ b/lib/index.esm.js
@@ -38,11 +38,13 @@ export default (function (props) {
 
       each(props, function (_ref4, propName) {
         var _ref4$formatter = _ref4.formatter,
-            formatter = _ref4$formatter === undefined ? defaultFormatter : _ref4$formatter;
+            formatter = _ref4$formatter === undefined ? defaultFormatter : _ref4$formatter,
+            _ref4$deep = _ref4.deep,
+            deep = _ref4$deep === undefined ? false : _ref4$deep;
 
         _this2.$watch(propName, function (value) {
           _this2[options.localName][propName] = formatter(value);
-        });
+        }, { deep: deep });
       });
     }
   };

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,11 +44,13 @@ exports.default = function (props) {
 
       (0, _lodash.each)(props, function (_ref4, propName) {
         var _ref4$formatter = _ref4.formatter,
-            formatter = _ref4$formatter === undefined ? defaultFormatter : _ref4$formatter;
+            formatter = _ref4$formatter === undefined ? defaultFormatter : _ref4$formatter,
+            _ref4$deep = _ref4.deep,
+            deep = _ref4$deep === undefined ? false : _ref4$deep;
 
         _this2.$watch(propName, function (value) {
           _this2[options.localName][propName] = formatter(value);
-        });
+        }, { deep: deep });
       });
     }
   };

--- a/package.json
+++ b/package.json
@@ -6,10 +6,13 @@
     "access": "public"
   },
   "main": "lib/index.js",
+  "module": "lib/index.esm.js",
   "scripts": {
     "prepublish": "npm run build",
     "start": "npm run build -- --watch",
-    "build": "babel src --out-dir lib",
+    "build": "npm run build:es && npm run build:commonjs",
+    "build:es": "BABEL_ENV='esm' babel src/index.js --out-file lib/index.esm.js",
+    "build:commonjs": "BABEL_ENV='commonjs' babel src --out-dir lib",
     "test": "echo \"Error: no test specified\" && exit 1",
     "publish/beta": "np prerelease --skip-cleanup --yolo --tag=beta"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -6,21 +6,27 @@ import {
 const defaultOptions = {
   localName: 'local',
 };
+const defaultFormatter = (value) => value
 
-export default (props, options = defaultOptions) => ({
-  props,
-  data() {
-    return {
-      [options.localName]: {
-        ...mapValues(props, (prop, propName) => this[propName]),
-      },
-    };
-  },
-  created() {
-    each(props, (prop, propName) => {
-      this.$watch(propName, (value) => {
-        this[options.localName][propName] = value;
+export default (props, options = defaultOptions) => {
+  const propsDefinitions = mapValues(props, ({ ...prop, formatter }) => ({
+    ...prop,
+  }))
+  return {
+    props: propsDefinitions,
+    data() {
+      return {
+        [options.localName]: {
+          ...mapValues(props, ({ formatter = defaultFormatter }, propName) => formatter(this[propName])),
+        },
+      };
+    },
+    created() {
+      each(props, ({ formatter = defaultFormatter }, propName) => {
+        this.$watch(propName, (value) => {
+          this[options.localName][propName] = formatter(value);
+        });
       });
-    });
-  },
-});
+    },
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -22,10 +22,10 @@ export default (props, options = defaultOptions) => {
       };
     },
     created() {
-      each(props, ({ formatter = defaultFormatter }, propName) => {
+      each(props, ({ formatter = defaultFormatter, deep = false }, propName) => {
         this.$watch(propName, (value) => {
           this[options.localName][propName] = formatter(value);
-        });
+        }, { deep });
       });
     },
   }


### PR DESCRIPTION
This PR exposes native module for webpack 2 
+ add a feature for formatting copied value (so it provides an easy to insert default to local state or clone, etc..)

example:
```
mixins: [
      propsToLocal({
        node: {
          required: true,
          formatter: (value) => defaults({ data: { kind: null } }, value),
        },
      }),
    ],
```
